### PR TITLE
Deal with common tags, and publish only useful measures

### DIFF
--- a/spectator/registry.py
+++ b/spectator/registry.py
@@ -119,8 +119,9 @@ class Registry:
             self._client.post_json(self._uri, json)
 
     def _should_send(self, id, value):
-        s = id.tags()['statistic']
-        return not math.isnan(value) and (value > 0 or s == 'gauge')
+        max_op = 10
+        op = self._operation(id.tags())
+        return not math.isnan(value) and (value > 0 or op == max_op)
 
     def _build_string_table(self, payload, data):
         strings = {'name': 0}
@@ -166,8 +167,6 @@ class Registry:
             payload.append(value)
         else:
             logger.warn("invalid statistic for %s", id)
-
-        return
 
     def _operation(self, tags):
         addOp = 0

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -85,7 +85,6 @@ class RegistryTest(unittest.TestCase):
             g.set(1)
             ms = r._get_measurements()
             self.assertEqual(2, len(ms))
-            r._publish()
             r.gauge('nan').set(float('nan'))
             r.counter('zero')
             ms = r._get_measurements()


### PR DESCRIPTION
Add the common tags to the measurements we publish. Only publish measurements which are useful:

* Counts that have a delta greater than 0

* Gauges that have a value