### PR TITLE
Send measurements in batches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     license='Apache 2.0',
     url='https://github.com/netflix/spectator-py/',
     packages=['spectator'],
+    install_requires=['future'],
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -143,8 +143,10 @@ class RegistryTest(unittest.TestCase):
                 'value': 42,
                 'tags': {'nf.app': 'app', 'name': 'g', 'statistic': 'gauge'}
             }
-            expected_entries = [expected_counter, expected_gauge]
+            expected_entries = [expected_gauge, expected_counter]
 
             payload = r._measurements_to_json(ms)
-            entries = self.payload_to_entries(payload)
+
+            # sort payload so we ensure we get gauges first
+            entries = sorted(self.payload_to_entries(payload), key=lambda m: m.get('op'))
             self.assertEqual(expected_entries, entries)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -148,5 +148,6 @@ class RegistryTest(unittest.TestCase):
             payload = r._measurements_to_json(ms)
 
             # sort payload so we ensure we get gauges first
-            entries = sorted(self.payload_to_entries(payload), key=lambda m: m.get('op'))
+            entries = sorted(self.payload_to_entries(payload),
+                             key=lambda m: m.get('op'))
             self.assertEqual(expected_entries, entries)


### PR DESCRIPTION
Split measurements into max-sized chunks before sending them to our
aggregator cluster. This introduces a new configuration option
`batch_size` that specifies the maximum number of measurements to send
at once.

For python 2.7 compatibility adds 'future' to the `install_requires`
since that's required for the `builtins` module.