### PR TITLE
remove build for 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{27,35,36}
+envlist = py{27,36}
 
 [testenv]
 basepython =
     py27: python2.7
-    py35: python3.5
     py36: python3.6
 deps =
     check-manifest


### PR DESCRIPTION
Fix #5, users can move to 3.6 if they have trouble with
3.5. We aren't going to spend time debugging it.