### PR TITLE
fix tests for python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
 

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -24,4 +24,4 @@ class CounterTest(unittest.TestCase):
         ms = c._measure()
         self.assertEqual(len(ms), 1)
         self.assertEqual(ms[CounterTest.tid.with_stat('count')], 1)
-        self.assertEquals(c.count(), 0)
+        self.assertEqual(c.count(), 0)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,6 @@ from spectator.http import HttpClient
 import gzip
 import io
 import json
-import sys
 import threading
 import unittest
 
@@ -113,13 +112,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         try:
             length = int(self.headers['Content-Length'])
             entity = io.BytesIO(self.rfile.read(length))
-            data = json.loads(gzip.GzipFile(fileobj=entity).read())
+            data = json.loads(gzip.GzipFile(fileobj=entity).read().decode())
             self.send_response(data["status"])
-            self.add_header('Content-Encoding', 'gzip')
+            self.send_header('Content-Encoding', 'gzip')
             self.end_headers()
             self.wfile.write(self._compress("received: {}".format(data)))
-        except:
-            e = sys.exc_info()[0]
+        except Exception as e:
             self.send_response(400)
             self.end_headers()
             msg = "error processing request: {}".format(e)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py{27,36}
+envlist = py{27,35,36}
 
 [testenv]
 basepython =
     py27: python2.7
+    py35: python3.5
     py36: python3.6
 deps =
     check-manifest


### PR DESCRIPTION
when working with a gzip object, you get bytes, which should be decoded
into a string, before passing it to the json module.

returning the exception directly as an error message from the http
server makes it clear why the test was failing.

this was tested successfully with 2.7.15, 3.5.5 and 3.6.5.