### PR TITLE
fix PercentileTimer.stopwatch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name='netflix-spectator-py',
-    version='0.1.8',
+    version='0.1.9',
     description='Python library for reporting metrics to Atlas.',
     long_description=read('README.md'),
     author='Brian Harrington',
@@ -42,5 +42,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/spectator/histogram/percentiles.py
+++ b/spectator/histogram/percentiles.py
@@ -432,6 +432,7 @@ class PercentileTimer:
             self._tags = tags
         self._min = min * 1e9
         self._max = max * 1e9
+        self._clock = registry.clock()
         self._timer = self._registry.timer(self._name, self._tags)
         self._counters = [
             self._counter_for(i) for i in range(PercentileBuckets.length())

--- a/tests/test_percentiles.py
+++ b/tests/test_percentiles.py
@@ -1,4 +1,5 @@
 from spectator import Registry
+from spectator import ManualClock
 from spectator.histogram import PercentileBuckets
 from spectator.histogram import PercentileDistributionSummary
 from spectator.histogram import PercentileTimer
@@ -110,6 +111,14 @@ class PercentileTimerTest(unittest.TestCase):
     def test_with_threshold_2(self):
         r = Registry()
         t = PercentileTimer(r, "test", min=0, max=100)
+        self._check_percentiles(t, 0)
+
+    def test_stopwatch(self):
+        clock = ManualClock()
+        r = Registry(clock=clock)
+        t = PercentileTimer(r, "test", min=0, max=100)
+        with t.stopwatch():
+            clock.set_monotonic_time(1.0)
         self._check_percentiles(t, 0)
 
 


### PR DESCRIPTION
It was broken before because the `_clock` attribute was
not set.