### PR TITLE
Return a noop meter if a meterId is reused for a different meter type

### DIFF
--- a/spectator/counter.py
+++ b/spectator/counter.py
@@ -1,7 +1,37 @@
+from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
+
 from spectator.atomicnumber import AtomicNumber
 
 
-class Counter:
+class AbstractCounter(with_metaclass(ABCMeta)):
+
+    @abstractmethod
+    def increment(self, amount=1):
+        pass
+
+    @abstractmethod
+    def count(self):
+        pass
+
+    @abstractmethod
+    def _measure(self):
+        pass
+
+
+class NoopCounter(AbstractCounter):
+
+    def increment(self, amount=1):
+        pass
+
+    def count(self):
+        return 0
+
+    def _measure(self):
+        return {}
+
+
+class Counter(AbstractCounter):
 
     def __init__(self, meterId):
         self.meterId = meterId

--- a/spectator/distsummary.py
+++ b/spectator/distsummary.py
@@ -1,7 +1,44 @@
+from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
+
 from spectator.atomicnumber import AtomicNumber
 
 
-class DistributionSummary:
+class AbstractDistributionSummary(with_metaclass(ABCMeta)):
+
+    @abstractmethod
+    def record(self, amount):
+        pass
+
+    @abstractmethod
+    def count(self):
+        pass
+
+    @abstractmethod
+    def total_amount(self):
+        pass
+
+    @abstractmethod
+    def _measure(self):
+        pass
+
+
+class NoopDistributionSummary(AbstractDistributionSummary):
+
+    def record(self, amount):
+        pass
+
+    def count(self):
+        return 0
+
+    def total_amount(self):
+        return 0
+
+    def _measure(self):
+        return {}
+
+
+class DistributionSummary(AbstractDistributionSummary):
 
     def __init__(self, meterId):
         self.meterId = meterId

--- a/spectator/gauge.py
+++ b/spectator/gauge.py
@@ -1,7 +1,37 @@
+from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
+
 from spectator.atomicnumber import AtomicNumber
 
 
-class Gauge:
+class AbstractGauge(with_metaclass(ABCMeta)):
+
+    @abstractmethod
+    def get(self):
+        pass
+
+    @abstractmethod
+    def set(self, value):
+        pass
+
+    @abstractmethod
+    def _measure(self):
+        pass
+
+
+class NoopGauge(AbstractGauge):
+
+    def get(self):
+        return 0
+
+    def set(self, value):
+        pass
+
+    def _measure(self):
+        return {}
+
+
+class Gauge(AbstractGauge):
 
     def __init__(self, meterId):
         self.meterId = meterId

--- a/spectator/timer.py
+++ b/spectator/timer.py
@@ -1,8 +1,52 @@
+from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
+
 from spectator.atomicnumber import AtomicNumber
 from spectator.clock import SystemClock
 
 
-class Timer:
+class AbstractTimer(with_metaclass(ABCMeta)):
+
+    @abstractmethod
+    def record(self, amount):
+        pass
+
+    @abstractmethod
+    def stopwatch(self):
+        pass
+
+    @abstractmethod
+    def count(self):
+        pass
+
+    @abstractmethod
+    def total_time(self):
+        pass
+
+    @abstractmethod
+    def _measure(self):
+        pass
+
+
+class NoopTimer(AbstractTimer):
+
+    def record(self, amount):
+        pass
+
+    def stopwatch(self):
+        return StopWatch(self)
+
+    def count(self):
+        return 0
+
+    def total_time(self):
+        return 0
+
+    def _measure(self):
+        return {}
+
+
+class Timer(AbstractTimer):
 
     def __init__(self, meterId, clock=SystemClock()):
         self.meterId = meterId

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,8 +1,7 @@
 import builtins
 import unittest
 
-from spectator import ManualClock
-from spectator import Registry
+from spectator import ManualClock, Registry
 
 
 class RegistryTest(unittest.TestCase):
@@ -151,3 +150,38 @@ class RegistryTest(unittest.TestCase):
             entries = sorted(self.payload_to_entries(payload),
                              key=lambda m: m.get('op'))
             self.assertEqual(expected_entries, entries)
+
+    def test_duplicate_gauge_different_type(self):
+        r = Registry()
+        c = r.counter("check_value", tags=dict(taga="a"))
+        g = r.gauge("check_value", tags=dict(taga="a"))
+        self.assertIsNot(c, g)
+        self.assertIs(g, r.noopGauge)
+
+    def test_duplicate_counter_different_type(self):
+        r = Registry()
+        g = r.gauge("check_value", tags=dict(taga="a"))
+        c = r.counter("check_value", tags=dict(taga="a"))
+        self.assertIsNot(g, c)
+        self.assertIs(c, r.noopCounter)
+
+    def test_duplicate_timer_different_type(self):
+        r = Registry()
+        c = r.counter("check_value")
+        t = r.timer("check_value")
+        self.assertIsNot(c, t)
+        self.assertIs(t, r.noopTimer)
+
+    def test_duplicate_distro_different_type(self):
+        r = Registry()
+        c = r.counter("check_value")
+        d = r.distribution_summary("check_value")
+        self.assertIsNot(c, d)
+        self.assertIs(d, r.noopDistributionSummary)
+
+    def test_timer_and_counter_same_name_different_tags(self):
+        r = Registry()
+        c = r.counter("check_value", tags=dict(tag="a"))
+        t = r.timer("check_value", tags=dict(tag="b"))
+        self.assertIsNot(c, t)
+        self.assertIsNot(t, r.noopTimer)


### PR DESCRIPTION
If an existing meter already exists when creating a new one, the existing one is returned. For example:
```
my_gauge = GlobalRegistry.gauge('test')
test_gauge = GlobalRegistry.gauge('test')

my_gauge == test_gauge # True
```

However, if the second meter requested is of a different type, a meter of the first is returned. For example:
```
my_gauge = GlobalRegistry.gauge('test')
my_counter = GlobalRegistry.counter('test')

my_guage == my_counter # Returns True
my_counter.increment() # Raises exception because it is a gauge and gauges don't have a increment method
```

This PR brings spectator-py closer to parity by returning a Noop meter if a duplicate meterId is used when requesting a different meter type. The new behavior is:

```
my_gauge = GlobalRegistry.gauge('test')
my_counter = GlobalRegistry.counter('test')

my_guage == my_counter # Returns False
my_counter.increment() # Does nothing and is not reported.
```