### PR TITLE
Use strings for key, value in tags

### DIFF
--- a/spectator/id.py
+++ b/spectator/id.py
@@ -1,7 +1,7 @@
 class MeterId:
     def __init__(self, name, tags={}):
         self.name = name
-        self._tags = tags.copy()
+        self._tags = self.sanitize(tags)
 
     def tags(self):
         return self._tags.copy()
@@ -31,3 +31,10 @@ class MeterId:
         items = sorted(self._tags.items())
         tagStr = ",".join(["{}={}".format(t[0], t[1]) for t in items])
         return "{}:{}".format(self.name, tagStr)
+
+    @staticmethod
+    def sanitize(tags):
+        t = {}
+        for k, v in tags.items():
+            t[str(k)] = str(v)
+        return t

--- a/tests/test_id.py
+++ b/tests/test_id.py
@@ -35,3 +35,7 @@ class MeterIdTest(unittest.TestCase):
         tags["b"] = "2"
         self.assertEqual(tags, {"a": "1", "b": "2"})
         self.assertEqual(id1.tags(), {"a": "1"})
+
+    def test_tags_stringify(self):
+        id1 = MeterId("foo", {"a": False, "b": 1, "c": "2"})
+        self.assertEqual(id1.tags(), {"a": "False", "b": "1", "c": "2"})


### PR DESCRIPTION
Ensure that the keys and values for user supplied tags are converted to
strings. Some users of this library complained about the difficulty of
tracking down errors like the following:

```
registry polling failed: <class 'TypeError'>
Traceback (most recent call last):
  File "/apps/titusjob/lib/python3.6/site-packages/spectator/registry.py", line 222, in _run
    self._function()
  File "/apps/titusjob/lib/python3.6/site-packages/spectator/registry.py", line 141, in _publish
    self._send_batch(snapshot[i:end])
  File "/apps/titusjob/lib/python3.6/site-packages/spectator/registry.py", line 127, in _send_batch
    json = self._measurements_to_json(batch)
  File "/apps/titusjob/lib/python3.6/site-packages/spectator/registry.py", line 170, in _measurements_to_json
    strings = self._build_string_table(payload, data)
  File "/apps/titusjob/lib/python3.6/site-packages/spectator/registry.py", line 161, in _build_string_table
    keys.sort()
TypeError: '<' not supported between instances of 'bool' and 'str'
```

When there are many dependencies they do not own directly.