### PR TITLE
honor existing statistic if present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name='netflix-spectator-py',
-    version='0.1.11',
+    version='0.1.12',
     description='Python library for reporting metrics to Atlas.',
     long_description=read('README.md'),
     author='Brian Harrington',

--- a/spectator/counter.py
+++ b/spectator/counter.py
@@ -46,5 +46,5 @@ class Counter(AbstractCounter):
 
     def _measure(self):
         return {
-            self.meterId.with_stat('count'): self._count.get_and_set(0)
+            self.meterId.with_default_stat('count'): self._count.get_and_set(0)
         }

--- a/spectator/gauge.py
+++ b/spectator/gauge.py
@@ -52,7 +52,7 @@ class Gauge(AbstractGauge):
         return (self._clock.wall_time() - self._last_update.get()) > self.ttl
 
     def _measure(self):
-        id = self.meterId.with_stat('gauge')
+        id = self.meterId.with_default_stat('gauge')
 
         if self._has_expired():
             v = self._value.get_and_set(float('nan'))

--- a/spectator/id.py
+++ b/spectator/id.py
@@ -9,6 +9,12 @@ class MeterId:
     def with_stat(self, v):
         return self.with_tag('statistic', v)
 
+    def with_default_stat(self, v):
+        if 'statistic' in self._tags:
+            return self
+        else:
+            return self.with_stat(v)
+
     def with_tag(self, k, v):
         tags = self._tags.copy()
         tags[k] = v

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -25,3 +25,9 @@ class CounterTest(unittest.TestCase):
         self.assertEqual(len(ms), 1)
         self.assertEqual(ms[CounterTest.tid.with_stat('count')], 1)
         self.assertEqual(c.count(), 0)
+
+    def test_user_statistic(self):
+        c = Counter(CounterTest.tid.with_stat('totalTime'))
+        c.increment()
+        for id in c._measure().keys():
+            self.assertEqual('totalTime', id.tags()['statistic'])

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -33,3 +33,9 @@ class GaugeTest(unittest.TestCase):
         self.assertTrue(math.isnan(g.get()))
         self.assertEqual(1, len(ms))
         self.assertEqual(42, ms[GaugeTest.tid.with_stat('gauge')])
+
+    def test_user_statistic(self):
+        g = Gauge(GaugeTest.tid.with_stat('duration'))
+        g.set(42)
+        for id in g._measure().keys():
+            self.assertEqual('duration', id.tags()['statistic'])


### PR DESCRIPTION
For counters and gauges, the statistic provided on the id
should be used if present. This allows these base types to
be used as a building block for other composite types.