### PR TITLE
fix tox testing configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,11 @@ deps =
     readme_renderer
     flake8
     pytest
+    twine
 commands =
     check-manifest --ignore OSSMETADATA,MANIFEST.in,tox.ini,tests*
-    python setup.py check -m -r -s
-    flake8 .
+    python setup.py check -m -s
+    flake8 spectator tests
     py.test tests
 
 [flake8]


### PR DESCRIPTION
* Checking reStructuredText as a part of setup.py check is deprecated. This
step should now use `twine check dist/*` after the wheel has been built. See
the following link for more details:

https://packaging.python.org/guides/making-a-pypi-friendly-readme#validating-restructuredtext-markup

* Restrict `flake8` execution to the `spectator` and `tests` directories, so
that it does not crawl a local virtualenv, if one has been installed.