### PR TITLE
add usage guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,97 @@ Supports Python >= 2.7, with Python >= 3.6 recommended.
 [documentation]: https://netflix.github.io/atlas-docs/spectator/
 [usage]: https://netflix.github.io/atlas-docs/spectator/lang/py/usage/
 
+## Usage
+
+Importing the `GlobalRegistry` sets up Spectator to report data to an Atlas Aggregator backend
+every five seconds. A configuration package must be installed in order for this step to succeed.
+At Netflix, the configuration package is named `netflix-spectator-pyconf`.
+
+```python
+from spectator import GlobalRegistry
+```
+
+Once the `GlobalRegistry` is imported, it is used to create and manage Meters.
+
+## Meter Types
+
+### Counters
+
+A Counter is used to measure the rate at which an event is occurring. Considering an API
+endpoint, a Counter could be used to measure the rate at which it is being accessed.
+
+Counters are reported to the backend as a rate-per-second. In Atlas, the `:per-step` operator
+can be used to convert them back into a value-per-step on a graph.
+
+Call `increment()` when an event occurs:
+
+```python
+GlobalRegistry.counter('server.numRequests').increment()
+```
+
+You can also pass a value to `increment()`. This is useful when a collection of events happens
+together:
+
+```python
+GlobalRegistry.counter('queue.itemsAdded').increment(10)
+```
+
+### Distribution Summaries
+
+A Distribution Summary is used to track the distribution of events. It is similar to a Timer, but
+more general, in that the size does not have to be a period of time. For example, a Distribution
+Summary could be used to measure the payload sizes of requests hitting a server.
+
+Always use base units when recording data, to ensure that the tick labels presented on Atlas graphs
+are readable. If you are measuring payload size, then use bytes, not kilobytes (or some other unit).
+This means that a `4K` tick label will represent 4 kilobytes, rather than 4 kilo-kilobytes.
+
+Call `record()` with a value:
+
+```python
+GlobalRegistry.distribution_summary('server.requestSize').record(10)
+```
+
+### Gauges
+
+A gauge is a value that is sampled at some point in time. Typical examples for gauges would be
+the size of a queue or number of threads in a running state. Since gauges are not updated inline
+when a state change occurs, there is no information about what might have occurred between samples.
+
+Consider monitoring the behavior of a queue of tasks. If the data is being collected once a minute,
+then a gauge for the size will show the size when it was sampled. The size may have been much
+higher or lower at some point during interval, but that is not known.
+
+Call `set()` with a value:
+
+```python
+GlobalRegistry.gauge('server.queueSize').set(10)
+```
+
+Gauges are designed to report the last set value for 15 minutes. This done so that updates to the
+values do not need to be collected on a tight 1-minute schedule to ensure that Atlas shows
+unbroken lines in graphs.
+
+If you wish to no longer report a Gauge value, then set it to `float('nan')`. This is a separate
+and distinct value from `'nan'` or `'NaN'`, which are strings.
+
+### Timers
+
+A Timer is used to measure how long (in seconds) some event is taking.
+
+Call `record()` with a value:
+
+```python
+GlobalRegistry.timer('server.requestLatency').record(0.01)
+```
+
+Timers will keep track of the following statistics as they are used:
+
+* `count`
+* `totalTime`
+* `totalOfSquares`
+* `max`
+
 ## Local Development
 
 * Install [pyenv](https://github.com/pyenv/pyenv), possibly with [Homebrew](https://brew.sh/).


### PR DESCRIPTION
We occasionally get a few questions about how to use the spectator-py library
in our support channels. This change copies a bit of descriptive text from the
original Spectator Java library docs and adds some notes specific to Python
usage. In particular, it calls out the correct method of stopping publication
of Gauge values.