### PR TITLE
add python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 matrix:
   include:
+    - python: 3.5
+      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python port of the [Spectator] library for Java.
 
 See the Spectator [documentation] for an overview of core concepts and details on [usage].
 
-Supports Python >= 3.6.
+Supports Python >= 3.5, which is the oldest system Python 3 available on our commonly used OSes.
 
 [Spectator]: https://github.com/Netflix/spectator/
 [documentation]: https://netflix.github.io/atlas-docs/spectator/
@@ -16,7 +16,7 @@ Supports Python >= 3.6.
 ## Local Development
 
 * Install [pyenv](https://github.com/pyenv/pyenv), possibly with [Homebrew](https://brew.sh/).
-* Install Python versions: 3.6, 3.7, and 3.8. Enable all versions globally.
+* Install Python versions: 3.5, 3.6, 3.7, and 3.8. Enable all versions globally.
 * Make changes and add tests.
 * `tox`
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name='netflix-spectator-py',
-    version='0.1.14',
+    version='0.1.15',
     description='Python library for reporting metrics to Atlas.',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
@@ -38,9 +38,8 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py{36,37,38}
+envlist = py{35,36,37,38}
 
 [testenv]
 basepython =
+    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
We wanted to move up to Python 3.6 as a minimum version, so that we could
start taking advantage of f-strings, but we also want this library to work
with the minimum number of dependencies outside of the system Python 3
provided by our chosen Linux distributions.

The oldest system Python in our base OS collection is 3.5, which won't be
retired until sometime in 2021. The next oldest at that point will be 3.6.