### PR TITLE
Improve fork() handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - python: 3.8
       env: TOXENV=py38
 
-dist: xenial
+dist: bionic
 
 install: pip install tox
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ See the Spectator [documentation] for an overview of core concepts and details o
 
 Supports Python >= 3.5, which is the oldest system Python 3 available on our commonly used OSes.
 
+Note that there is a risk of deadlock if you are running Python 3.6 or lower and using 
+`os.fork()` or using a library that will fork the process 
+(see [this section](#concurrent-usage-under-older-python) for workarounds),
+so **we recommend using Python >= 3.7**
+
 [Spectator]: https://github.com/Netflix/spectator/
 [documentation]: https://netflix.github.io/atlas-docs/spectator/
 [usage]: https://netflix.github.io/atlas-docs/spectator/lang/py/usage/
@@ -54,7 +59,9 @@ from spectator import GlobalRegistry
 
 Once the `GlobalRegistry` is imported, it is used to create and manage Meters.
 
-### Concurrent Usage
+### Concurrent Usage Under Older Python
+
+> :warning: **Use Python 3.7+ if possible**: But if you can't, here's a workaround to prevent deadlocks
 
 There is a known issue in Python where forking a process after a thread is started can lead to
 deadlocks. This is commonly seen when using the `multiprocessing` module with default settings.
@@ -83,6 +90,8 @@ WSGI_GUNICORN_PRELOAD = undef
 [Gunicorn]: https://gunicorn.org/
 
 #### Task Worker Forking
+
+> :warning: **Use Python 3.7+ if possible**: But if you can't, here's a workaround to prevent deadlocks
 
 For other pre-fork worker processing frameworks, such as [huey], you need to be careful about how
 and when you start the `GlobalRegistry` to avoid deadlocks in the background publish thread. You
@@ -120,6 +129,8 @@ workers, to help ensure that it is not started when the module is loaded.
 
 #### Generic Multiprocessing
 
+> :warning: **Use Python 3.7+ if possible**: But if you can't, here's a workaround to prevent deadlocks
+
 In Python 3, you can configure the start method to `spawn` for `multiprocessing`. This will cause
 the module to do a `fork()` followed by an `execve()` to start a brand new Python process.
 
@@ -130,7 +141,7 @@ from multiprocessing import set_start_method
 set_start_method("spawn")
 ```
 
-To configure thid option within a context:
+To configure this option within a context:
 
 ```python
 from multiprocessing import get_context

--- a/spectator/__init__.py
+++ b/spectator/__init__.py
@@ -16,6 +16,14 @@ try:
     if auto_start_global():
         GlobalRegistry.start()
         atexit.register(GlobalRegistry.stop)
+        try:
+            from os import register_at_fork
+            register_at_fork(before=GlobalRegistry.stop_without_publish,
+                             after_in_parent=GlobalRegistry.start,
+                             after_in_child=GlobalRegistry.clear_meters_and_start)
+        except ImportError:
+            pass
+
     else:
         logger.debug("module spectatorconfig auto-start is disabled - GlobalRegistry will not start")
 except ImportError:


### PR DESCRIPTION
For Python3.7+, improve fork() handling by stopping/starting the registry using 'os.register_at_fork()'