### PR TITLE
allow optional ttl seconds for gauges

### DIFF
--- a/spectator/registry.py
+++ b/spectator/registry.py
@@ -46,8 +46,9 @@ class Registry:
                                  tags: Optional[dict] = None) -> DistributionSummary:
         return DistributionSummary(self._new_meter(name, tags), meter_type="D", writer=self._writer)
 
-    def gauge(self, name: str, tags: Optional[dict] = None) -> Gauge:
-        return Gauge(self._new_meter(name, tags), writer=self._writer)
+    def gauge(self, name: str, tags: Optional[dict] = None,
+              ttl_seconds: Optional[int] = None) -> Gauge:
+        return Gauge(self._new_meter(name, tags), ttl_seconds=ttl_seconds, writer=self._writer)
 
     def max_gauge(self, name: str, tags: Optional[dict] = None) -> MaxGauge:
         return MaxGauge(self._new_meter(name, tags), writer=self._writer)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -49,6 +49,15 @@ class RegistryTest(unittest.TestCase):
         g.set(42)
         self.assertEqual("g:test:42", g._writer.last_line())
 
+    def test_gauge_ttl_seconds(self):
+        r = Registry(config=SidecarConfig({"sidecar.output-location": "memory"}))
+
+        g = r.gauge("test", ttl_seconds=120)
+        self.assertTrue(g._writer.is_empty())
+
+        g.set(42)
+        self.assertEqual("g,120:test:42", g._writer.last_line())
+
     def test_max_gauge(self):
         r = Registry(config=SidecarConfig({"sidecar.output-location": "memory"}))
 


### PR DESCRIPTION
More complete fix for https://github.com/Netflix/spectator-py/pull/43.