### PR TITLE
add SPECTATOR_OUTPUT_LOCATION environment variable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,16 @@ _METRIC_CLASS_MAP = {
 }
 ```
 
+If you need to override the default output location (udp) of the `GlobalRegistry`, then you can
+set a `SPECTATOR_OUTPUT_LOCATION` environment variable to one of the following values:
+
+* `none` - disable output
+* `memory` - write to memory (`SidecarWriter` internal list `_messages`)
+* `stdout` - write to standard out for the process
+* `stderr` - write to standard error for the process
+* `file://$path_to_file` - write to a file (e.g. `file:///tmp/foo/bar`)
+* `udp://$host:$port` - write to a UDP socket
+
 ## Migrating from 0.1.X to 0.2.X
 
 * This library no longer publishes directly to the Atlas backends. It now publishes to the

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name="netflix-spectator-py",
-    version="0.2.1",
+    version="0.2.2",
     python_requires=">3.5",
     description="Python library for reporting metrics to the Netflix Atlas Timeseries Database.",
     long_description=read("README.md"),

--- a/spectator/sidecarconfig.py
+++ b/spectator/sidecarconfig.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any
+from os import environ
+from typing import Any, Dict, Optional
 
 from spectator.commontags import common_tags
 
@@ -32,16 +33,37 @@ class SidecarConfig:
         """Common infrastructure tags from the Netflix environment variables."""
         return self._config.get("sidecar.common-tags", common_tags())
 
+    @staticmethod
+    def _valid_output_location(output: Optional[str]) -> bool:
+        if output is None:
+            return False
+        return (output in ["none", "memory", "stdout", "stderr"] or
+                output.startswith("file://") or
+                output.startswith("udp://"))
+
     def output_location(self) -> str:
         """
         The location where data will be emitted. Supported values include:
 
           * `none` - disable output
+          * `memory` - write to memory (SidecarWriter internal list `_messages`)
           * `stdout` - write to standard out for the process
           * `stderr` - write to standard error for the process
           * `file://$path_to_file` - write to a file (e.g. file:///tmp/foo/bar)
           * `udp://$host:$port` - write to a UDP socket
 
         The default value is the port used by SpectatorD.
+
+        The output location for the GlobalRegistry can be selected by configuring an
+        environment variable SPECTATOR_OUTPUT_LOCATION with one of the values listed
+        above. Setting a custom output location may be useful for integration testing.
         """
-        return self._config.get("sidecar.output-location", "udp://127.0.0.1:1234")
+        config_value = self._config.get("sidecar.output-location")
+        env_value = environ.get("SPECTATOR_OUTPUT_LOCATION")
+
+        if self._valid_output_location(config_value):
+            return config_value
+        elif self._valid_output_location(env_value):
+            return env_value
+        else:
+            return "udp://127.0.0.1:1234"

--- a/tests/test_sidecarconfig.py
+++ b/tests/test_sidecarconfig.py
@@ -50,3 +50,17 @@ class SidecarConfigTest(unittest.TestCase):
         self.assertEqual(self.all_expected_tags(), config.common_tags())
         self.assertEqual("stdout", config.output_location())
         self.clear_environment()
+
+    def test_valid_output_location(self):
+        config = SidecarConfig()
+        self.assertTrue(config._valid_output_location("none"))
+        self.assertTrue(config._valid_output_location("memory"))
+        self.assertTrue(config._valid_output_location("stdout"))
+        self.assertTrue(config._valid_output_location("stderr"))
+        self.assertTrue(config._valid_output_location("file://"))
+        self.assertTrue(config._valid_output_location("udp://"))
+
+    def test_invalid_output_location(self):
+        config = SidecarConfig()
+        self.assertFalse(config._valid_output_location(None))
+        self.assertFalse(config._valid_output_location("foo"))


### PR DESCRIPTION
We have a case where we want to disable sending messages to the udp socket
when running integration tests on CI servers which also happen to be running
SpectatorD. The applications under test use the GlobalRegistry liberally.
    
The SPECTATOR_OUTPUT_LOCATION environment variable may be set to "none" to
disable publishing messages, or "memory" if there is a need to verify the
messages.
