### PR TITLE
add spectatord line protocol parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,26 @@ The `MemoryWriter` subclass offers a few methods to inspect the values that it c
 * `is_empty()` - Is the internal list empty?
 * `last_line()` - Return the last element of the internal list.
 
+Lastly, a SpectatorD line protocol parser is available, which is intended to be used for validating
+the results captured by a `MemoryWriter`. It may be used as follows:
+
+```python
+import unittest
+
+from spectator.counter import Counter
+from spectator.protocolparser import parse_protocol_line
+
+
+class ProtocolParserTest(unittest.TestCase):
+
+def test_parse_counter_with_multiple_tags(self):
+       meter_class, meter_id, value = parse_protocol_line("c:test,foo=bar,baz=quux:1")
+       self.assertEqual(Counter, meter_class)
+       self.assertEqual("test", meter_id.name)
+       self.assertEqual({"foo": "bar", "baz": "quux"}, meter_id.tags())
+       self.assertEqual("1", value)
+```
+
 ## Migrating from 0.1.X to 0.2.X
 
 * This library no longer publishes directly to the Atlas backends. It now publishes to the

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name="netflix-spectator-py",
-    version="0.2.3",
+    version="0.2.4",
     python_requires=">3.5",
     description="Python library for reporting metrics to the Netflix Atlas Timeseries Database.",
     long_description=read("README.md"),

--- a/spectator/protocolparser.py
+++ b/spectator/protocolparser.py
@@ -1,0 +1,39 @@
+from typing import Tuple, Type
+
+from spectator.counter import Counter, MonotonicCounter
+from spectator.distsummary import DistributionSummary
+from spectator.gauge import AgeGauge, Gauge, MaxGauge
+from spectator.id import MeterId
+from spectator.sidecarmeter import SidecarMeter
+from spectator.timer import Timer
+
+# https://github.com/Netflix-Skunkworks/spectatord#metric-types
+_METER_CLASS_MAP = {
+    'c': Counter,
+    'd': DistributionSummary,
+    'g': Gauge,
+    'm': MaxGauge,
+    't': Timer,
+    'A': AgeGauge,
+    'C': MonotonicCounter,
+    'D': DistributionSummary,
+    'T': Timer
+}
+
+
+def parse_protocol_line(line: str) -> Tuple[Type[SidecarMeter], MeterId, str]:
+    """Parse SpectatorD protocol lines and return a Tuple of data which can be used to validate
+    that the line matches expectations in tests."""
+    meter_type, meter_id, value = line.split(":")
+
+    meter_class = _METER_CLASS_MAP.get(meter_type.split(",")[0])
+
+    meter_id = meter_id.split(",")
+    name = meter_id[0]
+    tags = {}
+
+    for tag in meter_id[1:]:
+        k, v = tag.split("=")
+        tags[k] = v
+
+    return meter_class, MeterId(name, tags), value

--- a/tests/test_protocolparser.py
+++ b/tests/test_protocolparser.py
@@ -1,0 +1,59 @@
+import unittest
+
+from spectator.counter import Counter
+from spectator.gauge import Gauge
+from spectator.protocolparser import parse_protocol_line
+from spectator.timer import Timer
+
+
+class ProtocolParserTest(unittest.TestCase):
+
+    def test_parse_invalid_lines(self):
+        with self.assertRaises(ValueError):
+            parse_protocol_line("foo")
+        with self.assertRaises(ValueError):
+            parse_protocol_line("foo:bar")
+        with self.assertRaises(ValueError):
+            parse_protocol_line("foo:bar,baz-quux")
+
+    def test_parse_counter(self):
+        meter_class, meter_id, value = parse_protocol_line("c:test:1")
+        self.assertEqual(Counter, meter_class)
+        self.assertEqual("test", meter_id.name)
+        self.assertEqual({}, meter_id.tags())
+        self.assertEqual("1", value)
+
+    def test_parse_counter_with_tag(self):
+        meter_class, meter_id, value = parse_protocol_line("c:test,foo=bar:1")
+        self.assertEqual(Counter, meter_class)
+        self.assertEqual("test", meter_id.name)
+        self.assertEqual({"foo": "bar"}, meter_id.tags())
+        self.assertEqual("1", value)
+
+    def test_parse_counter_with_multiple_tags(self):
+        meter_class, meter_id, value = parse_protocol_line("c:test,foo=bar,baz=quux:1")
+        self.assertEqual(Counter, meter_class)
+        self.assertEqual("test", meter_id.name)
+        self.assertEqual({"foo": "bar", "baz": "quux"}, meter_id.tags())
+        self.assertEqual("1", value)
+
+    def test_parse_gauge(self):
+        meter_class, meter_id, value = parse_protocol_line("g:test:1")
+        self.assertEqual(Gauge, meter_class)
+        self.assertEqual("test", meter_id.name)
+        self.assertEqual({}, meter_id.tags())
+        self.assertEqual("1", value)
+
+    def test_parse_gauge_with_ttl(self):
+        meter_class, meter_id, value = parse_protocol_line("g,120:test:1")
+        self.assertEqual(Gauge, meter_class)
+        self.assertEqual("test", meter_id.name)
+        self.assertEqual({}, meter_id.tags())
+        self.assertEqual("1", value)
+
+    def test_parse_timer(self):
+        meter_class, meter_id, value = parse_protocol_line("t:test:1")
+        self.assertEqual(Timer, meter_class)
+        self.assertEqual("test", meter_id.name)
+        self.assertEqual({}, meter_id.tags())
+        self.assertEqual("1", value)


### PR DESCRIPTION
This feature is intended to support testing by making it easier to validate
the values captured by a MemoryWriter.