### PR TITLE
Improve asyncio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ with t.stopwatch():
     time.sleep(5)
 ```
 
+## asyncio Support
+
+The `GlobalRegistry` provides a `UdpWriter` implementation of the `SidecarWriter` by default. UDP
+is a non-blocking, unordered and connectionless protocol, which is ideal for communicating with a
+local SpectatorD process in a variety of circumstances. The `UdpWriter` should be used in asyncio
+applications.
+
+The `PrintWriter` implementation, which can be used to communicate with the SpectatorD Unix domain
+socket, does not offer asyncio support at this time.
+
 ## Writing Tests
 
 To write tests against this library, instantiate a test instance of the Registry and configure it

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Snapshot](https://github.com/Netflix/spectator-py/actions/workflows/snapshot.yml/badge.svg)](https://github.com/Netflix/spectator-py/actions/workflows/snapshot.yml) [![Release](https://github.com/Netflix/spectator-py/actions/workflows/release.yml/badge.svg)](https://github.com/Netflix/spectator-py/actions/workflows/release.yml)
+[![Snapshot](https://github.com/Netflix/spectator-py/actions/workflows/snapshot.yml/badge.svg)](https://github.com/Netflix/spectator-py/actions/workflows/snapshot.yml)
 
 ## Introduction
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name="netflix-spectator-py",
-    version="0.2.6",
+    version="0.2.7",
     python_requires=">3.5",
     description="Python library for reporting metrics to the Netflix Atlas Timeseries Database.",
     long_description=read("README.md"),

--- a/spectator/sidecarwriter.py
+++ b/spectator/sidecarwriter.py
@@ -119,11 +119,10 @@ class UdpWriter(SidecarWriter):
     def __init__(self, location: str, address: Tuple[str, int]) -> None:
         super().__init__(location)
         self._address = address
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._sock.connect(self._address)
 
     def write_impl(self, line: str) -> None:
-        self._sock.send(bytes(line, encoding="utf-8"))
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.sendto(bytes(line, encoding="utf-8"), self._address)
 
     def close(self) -> None:
-        self._sock.close()
+        pass


### PR DESCRIPTION
The previous method of opening a socket during the UdpWriter init and re-using
it for sending packets was not universally usable with asyncio, because the
initial call was blocking, even though the send calls were non-blocking. This
meant that the initial import of the GlobalRegistry from spectator-py needed
to be handled outside of async code, to avoid BlockingIO errors, but otherwise,
metrics data would be sent as expected. This implementation was originally
selected, because it was thought that it performed slightly better than the
alternative.

This commit changes the implementation of the UdpWriter, so that a new socket
is opened within a context manager for every message that is sent to the
SpectatorD sidecar. The context manager ensures that the socket is closed
after the message is sent, so that we do not run out of file descriptors for
the process. These calls are all non-blocking, which means that the library
can now be used generally within asyncio applications, without needing to
consider where the initial import occurs. Re-testing with this method shows
that the performance is close to the original method.

The README is updated with advice on asyncio support.