### PR TITLE
enable ipv6-only support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     if: ${{ github.repository == 'Netflix/spectator-py' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 3.9

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     if: ${{ github.repository == 'Netflix/spectator-py' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -298,6 +298,31 @@ applications.
 The `PrintWriter` implementation, which can be used to communicate with the SpectatorD Unix domain
 socket, does not offer asyncio support at this time.
 
+## IPv6 Support
+
+By default, SpectatorD will listen on `IPv6 UDP *:1234`, without setting the `v6_only(true)`
+flag. On dual-stacked systems, this means that it will receive packets from both IPv4 and IPv6,
+and the IPv4 addresses will show up on the server as IPv4-mapped IPv6 addresses.
+
+By default, the `GlobalRegistry` will write UDP packets to `127.0.0.1:1234`, which will allow
+for communication with SpectatorD on dual-stacked systems.
+
+On IPv6-only systems, it may be necessary to change the default configuration using one of the
+following methods:
+
+* Configure the following environment variable, which will override the default configuration of
+the `GlobalRegistry`:
+
+      export SPECTATOR_OUTPUT_LOCATION="udp://[::1]:1234"
+
+* Configure a custom Registry, instead of using the `GlobalRegistry`:
+
+      from spectator import Registry
+      from spectator.sidecarconfig import SidecarConfig
+      
+      r = Registry(config=SidecarConfig({"sidecar.output-location": "udp://[::1]:1234"}))
+      r.counter("test").increment()
+
 ## Writing Tests
 
 To write tests against this library, instantiate a test instance of the Registry and configure it

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name="netflix-spectator-py",
-    version="0.2.9",
+    version="0.2.10",
     python_requires=">3.5",
     description="Python library for reporting metrics to the Netflix Atlas Timeseries Database.",
     long_description=read("README.md"),


### PR DESCRIPTION
The current implementation works for dual-stacked systems, but if we start seeing more ipv6-only systems, then we need to be able to pick the socket family correctly, given a configuration override.

This change does a check on the udp address to determine the family and uses that value for future connections. The readme has been updated with an explanation of how the current communication path works and how to set and override for ipv6-only systems.