### PR TITLE
implement feedback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ def read(fname):
 
 setup(
     name="netflix-spectator-py",
-    version="1.0.0rc1",
+    version="1.0.0rc2",
     python_requires=">3.9",
-    description="Python library for reporting metrics to the Netflix Atlas Timeseries Database.",
+    description="Python library for reporting metrics to SpectatorD and the Netflix Atlas Timeseries Database.",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     author="Netflix Telemetry Engineering",

--- a/spectator/clock.py
+++ b/spectator/clock.py
@@ -1,0 +1,41 @@
+import abc
+import time
+
+
+class Clock(metaclass=abc.ABCMeta):
+    def wall_time(self) -> float:
+        raise NotImplementedError
+
+    def monotonic_time(self) -> float:
+        raise NotImplementedError
+
+
+class SystemClock(Clock):
+    def wall_time(self) -> float:
+        return time.time()
+
+    def monotonic_time(self) -> float:
+        """Use `time.perf_counter()`, because it is a clock with the highest available resolution
+        to measure a short duration. It does include time elapsed during sleep and is system-wide.
+
+        See https://docs.python.org/3/library/time.html#time.perf_counter for more information."""
+        return time.perf_counter()
+
+
+class ManualClock(Clock):
+    """Used to enable deterministic unit testing for the StopWatch class."""
+    def __init__(self, wall_init: float = 0, monotonic_init: float = 0) -> None:
+        self._wall = wall_init
+        self._monotonic = monotonic_init
+
+    def wall_time(self) -> float:
+        return self._wall
+
+    def monotonic_time(self) -> float:
+        return self._monotonic
+
+    def set_wall_time(self, t: float) -> None:
+        self._wall = t
+
+    def set_monotonic_time(self, t: float) -> None:
+        self._monotonic = t

--- a/spectator/config.py
+++ b/spectator/config.py
@@ -25,14 +25,14 @@ class Config:
     with one of the values listed above. Overriding the output location may be useful for integration testing.
     """
 
-    def __init__(self, location: str = "udp", common_tags: Optional[Dict[str, str]] = None) -> None:
-        if common_tags is None:
-            common_tags = {}
-        self.common_tags = self.calculate_common_tags(common_tags)
+    def __init__(self, location: str = "udp", extra_common_tags: Optional[Dict[str, str]] = None) -> None:
+        if extra_common_tags is None:
+            extra_common_tags = {}
+        self.extra_common_tags = self.calculate_extra_common_tags(extra_common_tags)
         self.location = self.calculate_location(location)
 
     @staticmethod
-    def calculate_common_tags(common_tags: Dict[str, str]) -> Dict[str, str]:
+    def calculate_extra_common_tags(common_tags: Dict[str, str]) -> Dict[str, str]:
         merged_tags = validate_tags(common_tags)
 
         # merge common tags with env var tags; env vars take precedence

--- a/spectator/meter/__init__.py
+++ b/spectator/meter/__init__.py
@@ -1,14 +1,12 @@
 import abc
-import logging
 
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import WriterUnion
 
 
 class Meter(metaclass=abc.ABCMeta):
-    def __init__(self, id: Id, writer: WriterUnion, meter_type_symbol: str) -> None:
-        self._id = id
-        self._logger = logging.getLogger("spectator.meter")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion, meter_type_symbol: str) -> None:
+        self._id = meter_id
         self._meter_type_symbol = meter_type_symbol
         self._writer = writer
 

--- a/spectator/meter/age_gauge.py
+++ b/spectator/meter/age_gauge.py
@@ -1,5 +1,5 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -10,8 +10,8 @@ class AgeGauge(Meter):
     as the SpectatorD process runs. This meter type makes it easy to implement the Time Since
     Last Success alerting pattern."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "A")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "A")
 
     def now(self) -> None:
         line = f"{self._meter_type_symbol}:{self._id.spectatord_id}:0"

--- a/spectator/meter/counter.py
+++ b/spectator/meter/counter.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -9,8 +9,8 @@ class Counter(Meter):
     """The value is the number of increments that have occurred since the last time it was
     recorded. The value will be reported to the Atlas backend as a rate-per-second."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "c")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "c")
 
     def increment(self, delta: Union[int, float] = 1) -> None:
         if delta > 0:

--- a/spectator/meter/dist_summary.py
+++ b/spectator/meter/dist_summary.py
@@ -1,5 +1,5 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -9,8 +9,8 @@ class DistributionSummary(Meter):
     measure the payload sizes of requests hitting a server or the number of records returned
     from a query."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "d")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "d")
 
     def record(self, amount: int) -> None:
         if amount >= 0:

--- a/spectator/meter/gauge.py
+++ b/spectator/meter/gauge.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -9,14 +9,15 @@ class Gauge(Meter):
     """The value is a number that was sampled at a point in time. The default time-to-live (TTL)
     for gauges is 900 seconds (15 minutes) - they will continue reporting the last value set for
     this duration of time. An optional ttl_seconds may be set to control the lifespan of these
-    values. SpectatorD enforces a minimum ttl of 5 seconds."""
+    values. SpectatorD enforces a minimum TTL of 5 seconds."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none"), ttl_seconds: Optional[int] = None) -> None:
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none"),
+                 ttl_seconds: Optional[int] = None) -> None:
         if ttl_seconds is None:
             meter_type_symbol = "g"
         else:
             meter_type_symbol = f"g,{ttl_seconds}"
-        super().__init__(id, writer, meter_type_symbol)
+        super().__init__(meter_id, writer, meter_type_symbol)
 
     def set(self, value: float) -> None:
         line = f"{self._meter_type_symbol}:{self._id.spectatord_id}:{value}"

--- a/spectator/meter/max_gauge.py
+++ b/spectator/meter/max_gauge.py
@@ -1,5 +1,5 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -7,8 +7,8 @@ class MaxGauge(Meter):
     """The value is a number that was sampled at a point in time, but it is reported as a maximum
     gauge value to the backend."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "m")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "m")
 
     def set(self, value: float) -> None:
         line = f"{self._meter_type_symbol}:{self._id.spectatord_id}:{value}"

--- a/spectator/meter/meter_id.py
+++ b/spectator/meter/meter_id.py
@@ -5,13 +5,17 @@ from typing import Dict, Optional
 from spectator.common_tags import validate_tags
 
 
-class Id:
+class MeterId:
+    """The name and tags which uniquely identify a Meter instance. The tags are key-value pairs of
+    strings. This class should NOT be used directly. Instead, use the Registry.new_id() method, to
+    ensure that any extra common tags are properly applied to the Meter."""
+
     INVALID_CHARS = re.compile("[^-._A-Za-z0-9~^]")
 
     def __init__(self, name: str, tags: Optional[Dict[str, str]] = None) -> None:
         if tags is None:
             tags = {}
-        self._logger = logging.getLogger("spectator.meter.id")
+        self._logger = logging.getLogger(__name__)
         self._name = name
         self._tags = self._validate_tags(tags)
         self.spectatord_id = self._to_spectatord_id(self._name, self._tags)
@@ -45,17 +49,17 @@ class Id:
     def tags(self) -> Dict[str, str]:
         return self._tags.copy()
 
-    def with_tag(self, k: str, v: str) -> "Id":
+    def with_tag(self, k: str, v: str) -> "MeterId":
         new_tags = self._tags.copy()
         new_tags[k] = v
-        return Id(self._name, new_tags)
+        return MeterId(self._name, new_tags)
 
-    def with_tags(self, tags: Dict[str, str]) -> "Id":
+    def with_tags(self, tags: Dict[str, str]) -> "MeterId":
         if len(tags) == 0:
             return self
         new_tags = self._tags.copy()
         new_tags.update(tags)
-        return Id(self._name, new_tags)
+        return MeterId(self._name, new_tags)
 
     def __hash__(self):
         return hash((self._name, frozenset(self._tags.items())))

--- a/spectator/meter/monotonic_counter.py
+++ b/spectator/meter/monotonic_counter.py
@@ -1,5 +1,5 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -7,8 +7,8 @@ class MonotonicCounter(Meter):
     """The value is a monotonically increasing number. A minimum of two samples must be received
     in order for SpectatorD to calculate a delta value and report it to the backend."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "C")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "C")
 
     def set(self, amount: float) -> None:
         line = f"{self._meter_type_symbol}:{self._id.spectatord_id}:{amount}"

--- a/spectator/meter/monotonic_counter_uint.py
+++ b/spectator/meter/monotonic_counter_uint.py
@@ -1,16 +1,18 @@
 from ctypes import c_uint64
 
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
 class MonotonicCounterUint(Meter):
-    """The value is a monotonically increasing number. A minimum of two samples must be received
-    in order for SpectatorD to calculate a delta value and report it to the backend."""
+    """The value is a monotonically increasing number of an uint64 data type. These kinds of
+    values are commonly seen in networking metrics, such as bytes-per-second. A minimum of two
+    samples must be received in order for SpectatorD to calculate a delta value and report it to
+    the backend."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "U")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "U")
 
     def set(self, amount: c_uint64) -> None:
         line = f"{self._meter_type_symbol}:{self._id.spectatord_id}:{amount.value}"

--- a/spectator/meter/percentile_dist_summary.py
+++ b/spectator/meter/percentile_dist_summary.py
@@ -1,5 +1,5 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -14,8 +14,8 @@ class PercentileDistributionSummary(Meter):
     diligent about any additional dimensions added to Percentile Distribution Summaries and ensure
     that they have a small bounded cardinality."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "D")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "D")
 
     def record(self, amount: int) -> None:
         if amount >= 0:

--- a/spectator/meter/percentile_timer.py
+++ b/spectator/meter/percentile_timer.py
@@ -1,5 +1,5 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
@@ -12,8 +12,8 @@ class PercentileTimer(Meter):
     with a worst-case of up to 300X that of a standard Timer. Be diligent about any additional
     dimensions added to Percentile Timers and ensure that they have a small bounded cardinality."""
 
-    def __init__(self, id: Id, writer: WriterUnion = new_writer("none")) -> None:
-        super().__init__(id, writer, "T")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion = new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "T")
 
     def record(self, seconds: float) -> None:
         if seconds >= 0:

--- a/spectator/meter/timer.py
+++ b/spectator/meter/timer.py
@@ -1,15 +1,13 @@
 from spectator.meter import Meter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.new_writer import new_writer, WriterUnion
 
 
 class Timer(Meter):
-    """The value is the number of seconds that have elapsed for an event. A stopwatch method
-    is available, which provides a context manager that can be used to automate recording the
-    timing for a block of code using the `with` statement."""
+    """The value is the number of seconds that have elapsed for an event."""
 
-    def __init__(self, id: Id, writer: WriterUnion= new_writer("none")) -> None:
-        super().__init__(id, writer, "t")
+    def __init__(self, meter_id: MeterId, writer: WriterUnion= new_writer("none")) -> None:
+        super().__init__(meter_id, writer, "t")
 
     def record(self, seconds: float) -> None:
         if seconds >= 0:

--- a/spectator/protocol_parser.py
+++ b/spectator/protocol_parser.py
@@ -5,8 +5,8 @@ from spectator.meter.age_gauge import AgeGauge
 from spectator.meter.counter import Counter
 from spectator.meter.dist_summary import DistributionSummary
 from spectator.meter.gauge import Gauge
-from spectator.meter.id import Id
 from spectator.meter.max_gauge import MaxGauge
+from spectator.meter.meter_id import MeterId
 from spectator.meter.monotonic_counter import MonotonicCounter
 from spectator.meter.monotonic_counter_uint import MonotonicCounterUint
 from spectator.meter.percentile_dist_summary import PercentileDistributionSummary
@@ -32,8 +32,8 @@ def get_meter_class(symbol: str) -> Type[Meter]:
     return _METER_CLASSES.get(symbol)
 
 
-def parse_protocol_line(line: str) -> Tuple[str, Id, str]:
-    """Parse SpectatorD protocol line. Utility exposed for testing."""
+def parse_protocol_line(line: str) -> Tuple[str, MeterId, str]:
+    """Parse a SpectatorD protocol line into component parts. Utility exposed for testing."""
     symbol, id, value = line.split(":")
     # remove optional parts, such as gauge ttls
     symbol = symbol.split(",")[0]
@@ -45,4 +45,4 @@ def parse_protocol_line(line: str) -> Tuple[str, Id, str]:
         k, v = tag.split("=")
         tags[k] = v
 
-    return symbol, Id(name, tags), value
+    return symbol, MeterId(name, tags), value

--- a/spectator/registry.py
+++ b/spectator/registry.py
@@ -6,8 +6,8 @@ from spectator.meter.age_gauge import AgeGauge
 from spectator.meter.counter import Counter
 from spectator.meter.dist_summary import DistributionSummary
 from spectator.meter.gauge import Gauge
-from spectator.meter.id import Id
 from spectator.meter.max_gauge import MaxGauge
+from spectator.meter.meter_id import MeterId
 from spectator.meter.monotonic_counter import MonotonicCounter
 from spectator.meter.monotonic_counter_uint import MonotonicCounterUint
 from spectator.meter.percentile_dist_summary import PercentileDistributionSummary
@@ -21,9 +21,9 @@ class Registry:
 
     def __init__(self, config: Config = Config()) -> None:
         self._config = config
-        self._logger = logging.getLogger("spectator.registry")
+        self._logger = logging.getLogger(__name__)
         self._writer = new_writer(config.location)
-        self._logger.info("Create Registry with extra commonTags=%s", config.common_tags)
+        self._logger.info("Create Registry with extra_common_tags=%s", config.extra_common_tags)
 
     def writer(self) -> WriterUnion:
         return self._writer
@@ -35,73 +35,75 @@ class Registry:
         except IOError:
             self._logger.error("Error closing Registry Writer")
 
-    def new_id(self, name: str, tags: Optional[dict] = None) -> Id:
+    def new_id(self, name: str, tags: Optional[dict] = None) -> MeterId:
+        """Create a new MeterId, which applies any configured extra common tags,
+        and can be used as an input to the *_with_meter_id Registry methods."""
         if tags is None:
             tags = {}
 
-        new_id = Id(name, tags)
+        new_meter_id = MeterId(name, tags)
 
-        if len(self._config.common_tags) > 0:
-            new_id = new_id.with_tags(self._config.common_tags)
+        if len(self._config.extra_common_tags) > 0:
+            new_meter_id = new_meter_id.with_tags(self._config.extra_common_tags)
 
-        return new_id
+        return new_meter_id
 
     def age_gauge(self, name: str, tags: Optional[dict] = None) -> AgeGauge:
         return AgeGauge(self.new_id(name, tags), self._writer)
 
-    def age_gauge_with_id(self, id: Id) -> AgeGauge:
-        return AgeGauge(id, self._writer)
+    def age_gauge_with_meter_id(self, meter_id: MeterId) -> AgeGauge:
+        return AgeGauge(meter_id, self._writer)
 
     def counter(self, name: str, tags: Optional[dict] = None) -> Counter:
         return Counter(self.new_id(name, tags), self._writer)
 
-    def counter_with_id(self, id: Id) -> Counter:
-        return Counter(id, self._writer)
+    def counter_with_meter_id(self, meter_id: MeterId) -> Counter:
+        return Counter(meter_id, self._writer)
 
     def distribution_summary(self, name: str, tags: Optional[dict] = None) -> DistributionSummary:
         return DistributionSummary(self.new_id(name, tags), self._writer)
 
-    def distribution_summary_with_id(self, id: Id) -> DistributionSummary:
-        return DistributionSummary(id, self._writer)
+    def distribution_summary_with_meter_id(self, meter_id: MeterId) -> DistributionSummary:
+        return DistributionSummary(meter_id, self._writer)
 
     def gauge(self, name: str, tags: Optional[dict] = None, ttl_seconds: Optional[int] = None) -> Gauge:
         return Gauge(self.new_id(name, tags), self._writer, ttl_seconds)
 
-    def gauge_with_id(self, id: Id, ttl_seconds: Optional[int] = None) -> Gauge:
-        return Gauge(id, self._writer, ttl_seconds)
+    def gauge_with_meter_id(self, meter_id: MeterId, ttl_seconds: Optional[int] = None) -> Gauge:
+        return Gauge(meter_id, self._writer, ttl_seconds)
 
     def max_gauge(self, name: str, tags: Optional[dict] = None) -> MaxGauge:
         return MaxGauge(self.new_id(name, tags), self._writer)
 
-    def max_gauge_with_id(self, id: Id) -> MaxGauge:
-        return MaxGauge(id, self._writer)
+    def max_gauge_with_meter_id(self, meter_id: MeterId) -> MaxGauge:
+        return MaxGauge(meter_id, self._writer)
 
     def monotonic_counter(self, name: str, tags: Optional[dict] = None) -> MonotonicCounter:
         return MonotonicCounter(self.new_id(name, tags), self._writer)
 
-    def monotonic_counter_with_id(self, id: Id) -> MonotonicCounter:
-        return MonotonicCounter(id, self._writer)
+    def monotonic_counter_with_meter_id(self, meter_id: MeterId) -> MonotonicCounter:
+        return MonotonicCounter(meter_id, self._writer)
 
     def monotonic_counter_uint(self, name: str, tags: Optional[dict] = None) -> MonotonicCounterUint:
         return MonotonicCounterUint(self.new_id(name, tags), self._writer)
 
-    def monotonic_counter_uint_with_id(self, id: Id) -> MonotonicCounterUint:
-        return MonotonicCounterUint(id, self._writer)
+    def monotonic_counter_uint_with_meter_id(self, meter_id: MeterId) -> MonotonicCounterUint:
+        return MonotonicCounterUint(meter_id, self._writer)
 
     def pct_distribution_summary(self, name: str, tags: Optional[dict] = None) -> PercentileDistributionSummary:
         return PercentileDistributionSummary(self.new_id(name, tags), self._writer)
 
-    def pct_distribution_summary_with_id(self, id: id) -> PercentileDistributionSummary:
-        return PercentileDistributionSummary(id, self._writer)
+    def pct_distribution_summary_with_meter_id(self, meter_id: MeterId) -> PercentileDistributionSummary:
+        return PercentileDistributionSummary(meter_id, self._writer)
 
     def pct_timer(self, name: str, tags: Optional[dict] = None) -> PercentileTimer:
         return PercentileTimer(self.new_id(name, tags), self._writer)
 
-    def pct_timer_with_id(self, id: id) -> PercentileTimer:
-        return PercentileTimer(id, self._writer)
+    def pct_timer_with_meter_id(self, meter_id: MeterId) -> PercentileTimer:
+        return PercentileTimer(meter_id, self._writer)
 
     def timer(self, name: str, tags: Optional[dict] = None) -> Timer:
         return Timer(self.new_id(name, tags), self._writer)
 
-    def timer_with_id(self, id: id) -> Timer:
-        return Timer(id, self._writer)
+    def timer_with_meter_id(self, meter_id: MeterId) -> Timer:
+        return Timer(meter_id, self._writer)

--- a/spectator/stopwatch.py
+++ b/spectator/stopwatch.py
@@ -1,0 +1,23 @@
+from typing import Union
+
+from spectator.clock import Clock, SystemClock
+from spectator.meter.percentile_timer import PercentileTimer
+from spectator.meter.timer import Timer
+
+
+class StopWatch:
+    """Context Manager that records the duration of a with-statement block in a Timer or
+    PercentileTimer. It uses a custom Clock implementation to assist with unit testing."""
+
+    def __init__(self, timer: Union[PercentileTimer, Timer], clock: Clock = SystemClock()) -> None:
+        self._clock = clock
+        self._timer = timer
+
+    def __enter__(self) -> None:
+        self._start = self._clock.monotonic_time()
+
+    def __exit__(self, type_, value, traceback) -> None:
+        self._timer.record(self.duration())
+
+    def duration(self) -> float:
+        return self._clock.monotonic_time() - self._start

--- a/spectator/writer/__init__.py
+++ b/spectator/writer/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 class Writer(metaclass=abc.ABCMeta):
     def __init__(self):
-        self._logger = logging.getLogger("spectator.writer")
+        self._logger = logging.getLogger(__name__)
 
     @abc.abstractmethod
     def write(self, line: str) -> None:

--- a/tests/meter/test_age_gauge.py
+++ b/tests/meter/test_age_gauge.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.age_gauge import AgeGauge
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class AgeGaugeTest(unittest.TestCase):
-    tid = Id("age_gauge")
+    tid = MeterId("age_gauge")
 
     def test_now(self):
         g = AgeGauge(self.tid, MemoryWriter())

--- a/tests/meter/test_counter.py
+++ b/tests/meter/test_counter.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.counter import Counter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class CounterTest(unittest.TestCase):
-    tid = Id("counter")
+    tid = MeterId("counter")
 
     def test_increment(self):
         c = Counter(self.tid, MemoryWriter())

--- a/tests/meter/test_dist_summary.py
+++ b/tests/meter/test_dist_summary.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.dist_summary import DistributionSummary
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class DistributionSummaryTest(unittest.TestCase):
-    tid = Id("dist_summary")
+    tid = MeterId("dist_summary")
 
     def test_record(self):
         d = DistributionSummary(self.tid, MemoryWriter())

--- a/tests/meter/test_gauge.py
+++ b/tests/meter/test_gauge.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.gauge import Gauge
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class GaugeTest(unittest.TestCase):
-    tid = Id("gauge")
+    tid = MeterId("gauge")
 
     def test_set(self):
         g = Gauge(self.tid, MemoryWriter())

--- a/tests/meter/test_max_gauge.py
+++ b/tests/meter/test_max_gauge.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.max_gauge import MaxGauge
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class MaxGaugeTest(unittest.TestCase):
-    tid = Id("max_gauge")
+    tid = MeterId("max_gauge")
 
     def test_set(self):
         g = MaxGauge(self.tid, MemoryWriter())

--- a/tests/meter/test_meter_id.py
+++ b/tests/meter/test_meter_id.py
@@ -1,103 +1,103 @@
 import unittest
 
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 
 
 class MeterIdTest(unittest.TestCase):
 
     def test_different_types_not_equal(self):
-        id1 = Id("foo", {"a": "1"})
+        id1 = MeterId("foo", {"a": "1"})
         self.assertTrue(id1 != 1)
 
     def test_equals_same_name(self):
-        id1 = Id("foo")
-        id2 = Id("foo")
+        id1 = MeterId("foo")
+        id2 = MeterId("foo")
         self.assertEqual(id1, id2)
 
     def test_equals_same_tags(self):
-        id1 = Id("foo", {"a": "1", "b": "2", "c": "3"})
-        id2 = Id("foo", {"c": "3", "b": "2", "a": "1"})
+        id1 = MeterId("foo", {"a": "1", "b": "2", "c": "3"})
+        id2 = MeterId("foo", {"c": "3", "b": "2", "a": "1"})
         self.assertEqual(id1, id2)
 
     def test_hash_same_tags(self):
-        id1 = Id("foo", {"a": "1", "b": "2", "c": "3"})
-        id2 = Id("foo", {"c": "3", "b": "2", "a": "1"})
+        id1 = MeterId("foo", {"a": "1", "b": "2", "c": "3"})
+        id2 = MeterId("foo", {"c": "3", "b": "2", "a": "1"})
         self.assertEqual(hash(id1), hash(id2))
 
     def test_illegal_chars_are_replaced(self):
-        id = Id("test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo")
+        id = MeterId("test`!@#$%^&*()-=~_+[]{}\\|;:'\",<.>/?foo")
         self.assertEqual("test______^____-_~______________.___foo", id.spectatord_id)
 
     def test_invalid_tags(self):
         expected_messages = [
-            "WARNING:spectator.meter.id:Id(name=foo, tags={'k': ''}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=foo, tags={})",
-            "WARNING:spectator.meter.id:Id(name=bar, tags={'k': 1}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=bar, tags={})",
-            "WARNING:spectator.meter.id:Id(name=baz, tags={1: 'v'}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=baz, tags={})",
-            "WARNING:spectator.meter.id:Id(name=quux, tags={'k': 'v', 1: 'v'}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=quux, tags={'k': 'v'})",
+            "WARNING:spectator.meter.meter_id:Id(name=foo, tags={'k': ''}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=foo, tags={})",
+            "WARNING:spectator.meter.meter_id:Id(name=bar, tags={'k': 1}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=bar, tags={})",
+            "WARNING:spectator.meter.meter_id:Id(name=baz, tags={1: 'v'}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=baz, tags={})",
+            "WARNING:spectator.meter.meter_id:Id(name=quux, tags={'k': 'v', 1: 'v'}) is invalid due to tag keys or values which are not strings or are zero-length strings; proceeding with truncated tags Id(name=quux, tags={'k': 'v'})",
         ]
 
-        with self.assertLogs("spectator.meter.id", level='INFO') as logs:
-            id1 = Id("foo", {"k": ""})
+        with self.assertLogs("spectator.meter.meter_id", level='INFO') as logs:
+            id1 = MeterId("foo", {"k": ""})
             self.assertEqual("Id(name=foo, tags={})", str(id1))
-            id2 = Id("bar", {"k": 1})
+            id2 = MeterId("bar", {"k": 1})
             self.assertEqual("Id(name=bar, tags={})", str(id2))
-            id3 = Id("baz", {1: "v"})
+            id3 = MeterId("baz", {1: "v"})
             self.assertEqual("Id(name=baz, tags={})", str(id3))
-            id4 = Id("quux", {"k": "v", 1: "v"})
+            id4 = MeterId("quux", {"k": "v", 1: "v"})
             self.assertEqual("Id(name=quux, tags={'k': 'v'})", str(id4))
 
         self.assertEqual(expected_messages, logs.output)
 
     def test_lookup_tags(self):
-        id1 = Id("foo", {"a": "1", "b": "2", "c": "3"})
-        id2 = Id("foo", {"c": "3", "b": "2", "a": "1"})
+        id1 = MeterId("foo", {"a": "1", "b": "2", "c": "3"})
+        id2 = MeterId("foo", {"c": "3", "b": "2", "a": "1"})
         d = {id1: "test"}
         self.assertEqual("test", d[id2])
 
     def test_name(self):
-        id1 = Id("foo", {"a": "1"})
+        id1 = MeterId("foo", {"a": "1"})
         self.assertEqual("foo", id1.name())
 
     def test_spectatord_id(self):
-        id1 = Id("foo")
+        id1 = MeterId("foo")
         self.assertEqual("foo", id1.spectatord_id)
 
-        id2 = Id("bar", {"a": "1"})
+        id2 = MeterId("bar", {"a": "1"})
         self.assertEqual("bar,a=1", id2.spectatord_id)
 
-        id3 = Id("baz", {"a": "1", "b": "2"})
+        id3 = MeterId("baz", {"a": "1", "b": "2"})
         self.assertEqual("baz,a=1,b=2", id3.spectatord_id)
 
     def test_str(self):
-        id1 = Id("foo")
+        id1 = MeterId("foo")
         self.assertEqual("Id(name=foo, tags={})", str(id1))
 
-        id2 = Id("bar", {"a": "1"})
+        id2 = MeterId("bar", {"a": "1"})
         self.assertEqual("Id(name=bar, tags={'a': '1'})", str(id2))
 
-        id3 = Id("bar", {"a": "1", "b": "2", "c": "3"})
+        id3 = MeterId("bar", {"a": "1", "b": "2", "c": "3"})
         self.assertEqual("Id(name=bar, tags={'a': '1', 'b': '2', 'c': '3'})", str(id3))
 
     def test_tags(self):
-        id1 = Id("foo", {"a": "1"})
+        id1 = MeterId("foo", {"a": "1"})
         self.assertEqual({"a": "1"}, id1.tags())
 
     def test_tags_defensive_copy(self):
-        id1 = Id("foo", {"a": "1"})
+        id1 = MeterId("foo", {"a": "1"})
         tags = id1.tags()
         tags["b"] = "2"
         self.assertEqual({"a": "1", "b": "2"}, tags)
         self.assertEqual({"a": "1"}, id1.tags())
 
     def test_with_tag_returns_new_object(self):
-        id1 = Id("foo")
+        id1 = MeterId("foo")
         id2 = id1.with_tag("a", "1")
         self.assertNotEqual(id1, id2)
         self.assertEqual({}, id1.tags())
         self.assertEqual({"a": "1"}, id2.tags())
 
     def test_with_tags_returns_new_object(self):
-        id1 = Id("foo")
+        id1 = MeterId("foo")
         id2 = id1.with_tags({"a": "1", "b": "2"})
         self.assertNotEqual(id1, id2)
         self.assertEqual({}, id1.tags())

--- a/tests/meter/test_monotonic_counter.py
+++ b/tests/meter/test_monotonic_counter.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.monotonic_counter import MonotonicCounter
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class MonotonicCounterTest(unittest.TestCase):
-    tid = Id("monotonic_counter")
+    tid = MeterId("monotonic_counter")
 
     def test_set(self):
         c = MonotonicCounter(self.tid, writer=MemoryWriter())

--- a/tests/meter/test_monotonic_counter_uint.py
+++ b/tests/meter/test_monotonic_counter_uint.py
@@ -2,12 +2,12 @@ import ctypes
 import unittest
 
 from spectator.meter.monotonic_counter_uint import MonotonicCounterUint
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class MonotonicCounterUintTest(unittest.TestCase):
-    tid = Id("monotonic_counter_uint")
+    tid = MeterId("monotonic_counter_uint")
 
     def test_set(self):
         c = MonotonicCounterUint(self.tid, writer=MemoryWriter())

--- a/tests/meter/test_percentile_dist_summary.py
+++ b/tests/meter/test_percentile_dist_summary.py
@@ -1,12 +1,12 @@
 import unittest
 
 from spectator.meter.percentile_dist_summary import PercentileDistributionSummary
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class PercentileDistributionSummaryTest(unittest.TestCase):
-    tid = Id("percentile_dist_summary")
+    tid = MeterId("percentile_dist_summary")
 
     def test_record(self):
         d = PercentileDistributionSummary(self.tid, writer=MemoryWriter())

--- a/tests/meter/test_percentile_timer.py
+++ b/tests/meter/test_percentile_timer.py
@@ -1,12 +1,12 @@
 import unittest
 
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.meter.percentile_timer import PercentileTimer
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class PercentileTimerTest(unittest.TestCase):
-    tid = Id("percentile_timer")
+    tid = MeterId("percentile_timer")
 
     def test_record(self):
         t = PercentileTimer(self.tid, MemoryWriter())

--- a/tests/meter/test_timer.py
+++ b/tests/meter/test_timer.py
@@ -1,12 +1,12 @@
 import unittest
 
-from spectator.meter.id import Id
+from spectator.meter.meter_id import MeterId
 from spectator.meter.timer import Timer
 from spectator.writer.memory_writer import MemoryWriter
 
 
 class TimerTest(unittest.TestCase):
-    tid = Id("timer")
+    tid = MeterId("timer")
 
     def test_record(self):
         t = Timer(self.tid, MemoryWriter())

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,49 @@
+import time
+import unittest
+
+from spectator.clock import Clock, SystemClock, ManualClock
+
+
+class ClockTest(unittest.TestCase):
+    def test_wall_time_raises(self):
+        self.assertRaises(NotImplementedError, Clock().wall_time)
+
+    def test_monotonic_raises(self):
+        self.assertRaises(NotImplementedError, Clock().monotonic_time)
+
+
+class SystemClockTest(unittest.TestCase):
+    def test_wall_time(self):
+        c = SystemClock()
+        start = c.wall_time()
+        time.sleep(0.01)
+        end = c.wall_time()
+        self.assertTrue(end > start, "{} > {}".format(end, start))
+
+    def test_monotonic_time(self):
+        c = SystemClock()
+        start = c.monotonic_time()
+        time.sleep(0.01)
+        end = c.monotonic_time()
+        self.assertTrue(end > start, "{} > {}".format(end, start))
+
+
+class ManualClockTest(unittest.TestCase):
+    def test_init(self):
+        c1 = ManualClock()
+        self.assertEqual(0, c1.wall_time())
+        self.assertEqual(0, c1.monotonic_time())
+
+        c2 = ManualClock(1, 2)
+        self.assertEqual(1, c2.wall_time())
+        self.assertEqual(2, c2.monotonic_time())
+
+    def test_set_wall_time(self):
+        c = ManualClock()
+        c.set_wall_time(1)
+        self.assertEqual(1, c.wall_time())
+
+    def test_set_monotonic_time(self):
+        c = ManualClock()
+        c.set_monotonic_time(1)
+        self.assertEqual(1, c.monotonic_time())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,8 +50,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_extra_common_tags(self):
         self.setup_environment()
-        config = Config(common_tags={"extra-tag": "foo"})
-        self.assertEqual({'extra-tag': 'foo', 'nf.container': 'main', 'nf.process': 'python'}, config.common_tags)
+        config = Config(extra_common_tags={"extra-tag": "foo"})
+        self.assertEqual({'extra-tag': 'foo', 'nf.container': 'main', 'nf.process': 'python'}, config.extra_common_tags)
 
     def test_valid_output_locations(self):
         self.assertEqual("none", self.get_location("none"))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -34,7 +34,7 @@ class RegistryTest(unittest.TestCase):
     def test_age_gauge_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        g = r.age_gauge_with_id(r.new_id("age_gauge", {"my-tags": "bar"}))
+        g = r.age_gauge_with_meter_id(r.new_id("age_gauge", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         g.set(0)
@@ -65,7 +65,7 @@ class RegistryTest(unittest.TestCase):
     def test_counter_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        c = r.counter_with_id(r.new_id("counter", {"my-tags": "bar"}))
+        c = r.counter_with_meter_id(r.new_id("counter", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         c.increment()
@@ -89,7 +89,7 @@ class RegistryTest(unittest.TestCase):
     def test_distribution_summary_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        d = r.distribution_summary_with_id(r.new_id("distribution_summary", {"my-tags": "bar"}))
+        d = r.distribution_summary_with_meter_id(r.new_id("distribution_summary", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         d.record(42)
@@ -107,7 +107,7 @@ class RegistryTest(unittest.TestCase):
     def test_gauge_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        g = r.gauge_with_id(r.new_id("gauge", {"my-tags": "bar"}))
+        g = r.gauge_with_meter_id(r.new_id("gauge", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         g.set(42)
@@ -116,7 +116,7 @@ class RegistryTest(unittest.TestCase):
     def test_gauge_with_id_with_ttl_seconds(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        g = r.gauge_with_id(r.new_id("gauge", {"my-tags": "bar"}), ttl_seconds=120)
+        g = r.gauge_with_meter_id(r.new_id("gauge", {"my-tags": "bar"}), ttl_seconds=120)
         self.assertTrue(r.writer().is_empty())
 
         g.set(42)
@@ -134,16 +134,16 @@ class RegistryTest(unittest.TestCase):
     def test_max_gauge(self):
         r = Registry(Config("memory"))
 
-        g = r.max_gauge("test")
+        g = r.max_gauge("max_gauge")
         self.assertTrue(r.writer().is_empty())
 
         g.set(42)
-        self.assertEqual("m:test:42", r.writer().last_line())
+        self.assertEqual("m:max_gauge:42", r.writer().last_line())
 
     def test_max_gauge_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        g = r.max_gauge_with_id(r.new_id("max_gauge", {"my-tags": "bar"}))
+        g = r.max_gauge_with_meter_id(r.new_id("max_gauge", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         g.set(42)
@@ -161,7 +161,7 @@ class RegistryTest(unittest.TestCase):
     def test_monotonic_counter_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        c = r.monotonic_counter_with_id(r.new_id("monotonic_counter", {"my-tags": "bar"}))
+        c = r.monotonic_counter_with_meter_id(r.new_id("monotonic_counter", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         c.set(42)
@@ -188,7 +188,7 @@ class RegistryTest(unittest.TestCase):
     def test_pct_distribution_summary_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        d = r.pct_distribution_summary_with_id(r.new_id("pct_distribution_summary", {"my-tags": "bar"}))
+        d = r.pct_distribution_summary_with_meter_id(r.new_id("pct_distribution_summary", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         d.record(42)
@@ -197,34 +197,34 @@ class RegistryTest(unittest.TestCase):
     def test_pct_timer(self):
         r = Registry(Config("memory"))
 
-        t = r.pct_timer("timer")
+        t = r.pct_timer("pct_timer")
         self.assertTrue(r.writer().is_empty())
 
         t.record(42)
-        self.assertEqual("T:timer:42", r.writer().last_line())
+        self.assertEqual("T:pct_timer:42", r.writer().last_line())
 
     def test_pct_timer_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        t = r.pct_timer_with_id(r.new_id("timer", {"my-tags": "bar"}))
+        t = r.pct_timer_with_meter_id(r.new_id("pct_timer", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         t.record(42)
-        self.assertEqual("T:timer,extra-tags=foo,my-tags=bar:42", r.writer().last_line())
+        self.assertEqual("T:pct_timer,extra-tags=foo,my-tags=bar:42", r.writer().last_line())
 
     def test_timer(self):
         r = Registry(Config("memory"))
 
-        t = r.timer("test")
+        t = r.timer("timer")
         self.assertTrue(r.writer().is_empty())
 
         t.record(42)
-        self.assertEqual("t:test:42", r.writer().last_line())
+        self.assertEqual("t:timer:42", r.writer().last_line())
 
     def test_timer_with_id(self):
         r = Registry(Config("memory", {"extra-tags": "foo"}))
 
-        t = r.timer_with_id(r.new_id("timer", {"my-tags": "bar"}))
+        t = r.timer_with_meter_id(r.new_id("timer", {"my-tags": "bar"}))
         self.assertTrue(r.writer().is_empty())
 
         t.record(42)

--- a/tests/test_stopwatch.py
+++ b/tests/test_stopwatch.py
@@ -1,0 +1,29 @@
+import unittest
+
+from spectator.config import Config
+from spectator.registry import Registry
+from spectator.clock import ManualClock
+from spectator.stopwatch import StopWatch
+
+
+class StopwatchTest(unittest.TestCase):
+
+    def test_stopwatch_with_pct_timer(self):
+        r = Registry(Config("memory"))
+        t = r.timer("pct_timer")
+        self.assertTrue(r.writer().is_empty())
+
+        clock = ManualClock()
+        with StopWatch(t, clock):
+            clock.set_monotonic_time(33)
+        self.assertEqual("t:pct_timer:33", r.writer().last_line())
+
+    def test_stopwatch_with_timer(self):
+        r = Registry(Config("memory"))
+        t = r.timer("timer")
+        self.assertTrue(r.writer().is_empty())
+
+        clock = ManualClock()
+        with StopWatch(t, clock):
+            clock.set_monotonic_time(42)
+        self.assertEqual("t:timer:42", r.writer().last_line())


### PR DESCRIPTION
* Rename the `Id` class back to `MeterId`, because `Id` is overloaded and Python has a builtin `id`. This will help keep the uses of this class a distinct concept.
* Remove the `Meter` logger, because it was unused. All of the important logging happens in other places, such as the `MeterId` or the `Writer`.
* Rename all the loggers to `__name__`, because the Python logging module automatically keeps track of the hierarchy. For example, the `MeterId` logger name becomes `spectator.meter.meter_id`.
* Clarify the `extra_common_tags` concept, with parameter name changes, and docstrings.
* Restore the `StopWatch` class, which is provided as a convenience to developers, so that they do not need to recreate this everywhere that they want to use a Context Manager for timing functions. In this version, it is separated from the `PercentileTimer` and `Timer` meters, but it will support both types.
* Restore the `Clock`, `ManualClock`, and `SystemClock` classes, for the purpose of providing deterministic testing for the `StopWatch` class. These classes remain separated from the `Meter` classes, which no longer need it.