### PR TITLE
lower python minimum version to 3.6

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = netflix-spectator-py
-version = 1.0.0
+version = 1.0.1
 description = Library for reporting metrics from Python applications to SpectatorD and the Netflix Atlas Timeseries Database.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -10,7 +10,7 @@ license = Apache 2.0
 url = https://github.com/Netflix/spectator-py
 
 [options]
-python_requires = >3.8
+python_requires = >=3.6
 packages =
     spectator
     spectator.meter


### PR DESCRIPTION
This project does not use any special language features outside of f-strings, so we can lower the minimum version required. This should help avoid branching import strategies for projects that have not yet moved up to 3.8.