### PR TITLE
Change setup.cfg python_requires to allow Python 3.8.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license = Apache 2.0
 url = https://github.com/Netflix/spectator-py
 
 [options]
-python_requires = >3.8
+python_requires = >=3.8
 packages =
     spectator
     spectator.meter


### PR DESCRIPTION
https://netflix.github.io/atlas-docs/spectator/lang/py/usage/ states: "This library currently targets the Python >= 3.8."

In addition, the test matrix includes 3.8:
https://github.com/stacywsmith/spectator-py/blob/main/.github/workflows/pr.yml#L11

Based on this information, it appears that Python 3.8 was intended to be supported, but accidentally omitted in the python_requires line of setup.cfg.