### PR TITLE
reduce log levels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = netflix-spectator-py
-version = 1.0.0
+version = 1.0.1
 description = Library for reporting metrics from Python applications to SpectatorD and the Netflix Atlas Timeseries Database.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/spectator/registry.py
+++ b/spectator/registry.py
@@ -23,13 +23,13 @@ class Registry:
         self._config = config
         self._logger = logging.getLogger(__name__)
         self._writer = new_writer(config.location)
-        self._logger.info("Create Registry with extra_common_tags=%s", config.extra_common_tags)
+        self._logger.debug("Create Registry with extra_common_tags=%s", config.extra_common_tags)
 
     def writer(self) -> WriterUnion:
         return self._writer
 
     def close(self) -> None:
-        self._logger.info("Close Registry Writer")
+        self._logger.debug("Close Registry Writer")
         try:
             self._writer.close()
         except IOError:

--- a/spectator/writer/file_writer.py
+++ b/spectator/writer/file_writer.py
@@ -8,7 +8,7 @@ class FileWriter(Writer):
 
     def __init__(self, location: str, file: TextIO) -> None:
         super().__init__()
-        self._logger.info("initialize FileWriter to %s", location)
+        self._logger.debug("initialize FileWriter to %s", location)
         self._file = file
 
     def write(self, line: str) -> None:

--- a/spectator/writer/memory_writer.py
+++ b/spectator/writer/memory_writer.py
@@ -7,7 +7,7 @@ class MemoryWriter(Writer):
 
     def __init__(self) -> None:
         super().__init__()
-        self._logger.info("initialize MemoryWriter")
+        self._logger.debug("initialize MemoryWriter")
         self._messages = []
 
     def write(self, line: str) -> None:

--- a/spectator/writer/noop_writer.py
+++ b/spectator/writer/noop_writer.py
@@ -6,7 +6,7 @@ class NoopWriter(Writer):
 
     def __init__(self) -> None:
         super().__init__()
-        self._logger.info("initialize NoopWriter")
+        self._logger.debug("initialize NoopWriter")
 
     def write(self, line: str) -> None:
         self._logger.debug("write line=%s", line)

--- a/spectator/writer/udp_writer.py
+++ b/spectator/writer/udp_writer.py
@@ -10,7 +10,7 @@ class UdpWriter(Writer):
 
     def __init__(self, location: str, address: Tuple[str, int]) -> None:
         super().__init__()
-        self._logger.info("initialize UdpWriter to %s", location)
+        self._logger.debug("initialize UdpWriter to %s", location)
         self._address = address
 
         try:

--- a/tests/writer/test_noop_writer.py
+++ b/tests/writer/test_noop_writer.py
@@ -7,10 +7,11 @@ class NoopWriterTest(unittest.TestCase):
 
     def test_noop_writer_logs(self):
         expected_messages = [
-            "INFO:spectator.writer:initialize NoopWriter",
+            "DEBUG:spectator.writer:initialize NoopWriter",
+            "DEBUG:spectator.writer:write line=c:counter:1"
         ]
 
-        with self.assertLogs("spectator.writer", level='INFO') as logs:
+        with self.assertLogs("spectator.writer", level='DEBUG') as logs:
             noop_writer = new_writer("none")
             noop_writer.write("c:counter:1")
             noop_writer.close()


### PR DESCRIPTION
Most users have not found the info level logs related to the Registry or the Writers to be useful. Dropping these logs to debug level.