### PR TITLE
lazily open sockets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = netflix-spectator-py
-version = 1.0.4
+version = 1.0.5
 description = Library for reporting metrics from Python applications to SpectatorD and the Netflix Atlas Timeseries Database.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/spectator/writer/udp_writer.py
+++ b/spectator/writer/udp_writer.py
@@ -1,4 +1,5 @@
 import socket
+import threading
 from ipaddress import ip_address, IPv6Address
 from typing import Tuple
 
@@ -12,6 +13,8 @@ class UdpWriter(Writer):
         super().__init__()
         self._logger.debug("initialize UdpWriter to %s", location)
         self._address = address
+        self._lock = threading.Lock()
+        self._sock = None
 
         try:
             if type(ip_address(self._address[0])) is IPv6Address:
@@ -22,15 +25,22 @@ class UdpWriter(Writer):
             # anything that does not appear to be an IPv4 or IPv6 address (i.e. hostnames)
             self._family = socket.AF_INET
 
-        self._sock = socket.socket(family=self._family, type=socket.SOCK_DGRAM)
-
     def write(self, line: str) -> None:
         self._logger.debug("write line=%s", line)
 
         try:
+            # lazily instantiate the socket, in a thread-safe manner. this is necessary, because
+            # the legacy GlobalRegistry will configure a UdpWriter upon `import spectator`.
+            if self._sock is None:
+                with self._lock:
+                    if self._sock is None:
+                        self._sock = socket.socket(family=self._family, type=socket.SOCK_DGRAM)
+
             self._sock.sendto(bytes(line, encoding="utf-8"), self._address)
         except IOError:
             self._logger.error("failed to write line=%s", line)
+        except Exception as e:
+            self._logger.error("exception during write: %s", e)
 
     def close(self) -> None:
         self._sock.close()

--- a/spectator/writer/unix_writer.py
+++ b/spectator/writer/unix_writer.py
@@ -1,4 +1,5 @@
 import socket
+import threading
 
 from spectator.writer import Writer
 
@@ -9,16 +10,25 @@ class UnixWriter(Writer):
     def __init__(self, location: str) -> None:
         super().__init__()
         self._logger.debug("initialize UnixWriter to %s", location)
-        self._sock = socket.socket(family=socket.AF_UNIX, type=socket.SOCK_DGRAM)
         self._location = location
+        self._lock = threading.Lock()
+        self._sock = None
 
     def write(self, line: str) -> None:
         self._logger.debug("write line=%s", line)
 
         try:
+            # lazily instantiate the socket, in a thread-safe manner
+            if self._sock is None:
+                with self._lock:
+                    if self._sock is None:
+                        self._sock = socket.socket(family=socket.AF_UNIX, type=socket.SOCK_DGRAM)
+
             self._sock.sendto(bytes(line, encoding="utf-8"), self._location)
         except IOError:
             self._logger.error("failed to write line=%s", line)
+        except Exception as e:
+            self._logger.error("exception during write: %s", e)
 
     def close(self) -> None:
         self._sock.close()


### PR DESCRIPTION
The legacy `GlobalRegistry` will open sockets upon import (`UdpWriter` by default). For applications that spawn a lot of threads, we want to keep this behavior under control, so lazily instantiate the sockets for the `UnixWriter` and the `UdpWriter`. We implement a `threading.Lock` when instantiating the sockets, to help avoid races between threads.