### PR TITLE
fixes for mypy type checking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 
 ## all: clean test lint check-manifest
 .PHONY: all
-all: clean test lint check-manifest
+all: clean test lint typecheck check-manifest
 
 ## setup-venv: create new virtualenv with dev dependencies
 .PHONY: setup-venv
@@ -55,21 +55,6 @@ else
 	pytest --cov=spectator tests
 endif
 
-## coverage: produce a coverage report
-.PHONY: coverage
-coverage: .coverage
-ifeq ($(SYSTEM), Darwin)
-	$(ACTIVATE) coverage report -m
-	@echo
-	$(ACTIVATE) coverage html
-	@echo
-	open htmlcov/index.html
-else
-	coverage report -m
-	@echo
-	coverage html
-endif
-
 ## lint: run pylint on the project
 .PHONY: lint
 lint:
@@ -77,6 +62,15 @@ ifeq ($(SYSTEM), Darwin)
 	$(ACTIVATE) pylint --rcfile=.pylintrc-relaxed spectator tests
 else
 	pylint --rcfile=.pylintrc-relaxed spectator tests
+endif
+
+## typecheck: run mypy on the project
+.PHONY: typecheck
+typecheck:
+ifeq ($(SYSTEM), Darwin)
+	$(ACTIVATE) mypy spectator tests
+else
+	mypy spectator tests
 endif
 
 ## check-manifest: validate the manifest file
@@ -90,6 +84,21 @@ else
 	check-manifest --ignore $(MANIFEST_IGNORE)
 	@echo
 	python setup.py check --metadata --strict
+endif
+
+## coverage: produce a coverage report
+.PHONY: coverage
+coverage: .coverage
+ifeq ($(SYSTEM), Darwin)
+	$(ACTIVATE) coverage report -m
+	@echo
+	$(ACTIVATE) coverage html
+	@echo
+	open htmlcov/index.html
+else
+	coverage report -m
+	@echo
+	coverage html
 endif
 
 # DEBUG: print out a a variable via `make print-FOO`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = netflix-spectator-py
-version = 1.1.1
+version = 1.1.2
 description = Library for reporting metrics from Python applications to SpectatorD and the Netflix Atlas Timeseries Database.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -10,7 +10,7 @@ license = Apache 2.0
 url = https://github.com/Netflix/spectator-py
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.10
 packages =
     spectator
     spectator.meter
@@ -19,6 +19,7 @@ packages =
 [options.extras_require]
 dev =
     check-manifest
+    mypy
     pylint
     pytest-cov
     pytest

--- a/spectator/common_tags.py
+++ b/spectator/common_tags.py
@@ -17,7 +17,7 @@ def _add_non_empty(tags: Dict[str, str], tag: str, *env_vars: str) -> None:
 def tags_from_env_vars() -> Dict[str, str]:
     """Extract common infrastructure tags from the Netflix environment variables, which are
     specific to a process and thus cannot be managed by a shared SpectatorD instance."""
-    tags = {}
+    tags: Dict[str, str] = {}
     _add_non_empty(tags, "nf.container", "TITUS_CONTAINER_NAME")
     _add_non_empty(tags, "nf.process", "NETFLIX_PROCESS_NAME")
     return tags

--- a/spectator/meter/meter_id.py
+++ b/spectator/meter/meter_id.py
@@ -34,6 +34,9 @@ class MeterId:
         return self.INVALID_CHARS.sub("_", s)
 
     def _to_spectatord_id(self, name: str, tags: Optional[Dict[str, str]]) -> str:
+        if tags is None:
+            tags = {}
+
         result = self._replace_invalid_chars(name)
 
         for k, v in sorted(tags.items()):

--- a/spectator/protocol_parser.py
+++ b/spectator/protocol_parser.py
@@ -1,6 +1,6 @@
-from typing import Tuple, Type
+from abc import ABCMeta
+from typing import Optional, Tuple
 
-from spectator.meter import Meter
 from spectator.meter.age_gauge import AgeGauge
 from spectator.meter.counter import Counter
 from spectator.meter.dist_summary import DistributionSummary
@@ -28,20 +28,20 @@ _METER_CLASSES = {
 }
 
 
-def get_meter_class(symbol: str) -> Type[Meter]:
+def get_meter_class(symbol: str) -> Optional[ABCMeta]:
     return _METER_CLASSES.get(symbol)
 
 
 def parse_protocol_line(line: str) -> Tuple[str, MeterId, str]:
     """Parse a SpectatorD protocol line into component parts. Utility exposed for testing."""
-    symbol, id, value = line.split(":")
+    symbol, meter_id, value = line.split(":")
     # remove optional parts, such as gauge ttls
     symbol = symbol.split(",")[0]
-    id = id.split(",")
-    name = id[0]
+    meter_id_parts = meter_id.split(",")
+    name = meter_id_parts[0]
 
     tags = {}
-    for tag in id[1:]:
+    for tag in meter_id_parts[1:]:
         k, v = tag.split("=")
         tags[k] = v
 

--- a/spectator/writer/memory_writer.py
+++ b/spectator/writer/memory_writer.py
@@ -8,7 +8,7 @@ class MemoryWriter(Writer):
     def __init__(self) -> None:
         super().__init__()
         self._logger.info("initialize MemoryWriter")
-        self._messages = []
+        self._messages: List[str] = []
 
     def write(self, line: str) -> None:
         self._logger.debug("write line=%s", line)

--- a/spectator/writer/new_writer.py
+++ b/spectator/writer/new_writer.py
@@ -13,7 +13,7 @@ def new_writer(config: Config) -> WriterUnion:
     """Create a new Writer based on an output location."""
 
     if config.location == "none":
-        writer = NoopWriter()
+        writer: WriterUnion = NoopWriter()
     elif config.location == "memory":
         writer = MemoryWriter()
     elif config.location in ("stderr", "stdout"):

--- a/spectator/writer/socket_writer.py
+++ b/spectator/writer/socket_writer.py
@@ -2,11 +2,16 @@ import socket
 import threading
 import time
 from ipaddress import ip_address, IPv6Address
+from typing import Optional, Tuple, TypeAlias, Union
 from urllib.parse import urlparse
 
 from spectator.config import Config
 from spectator.writer import Writer
 from spectator.writer.line_buffer import LineBuffer
+
+InetFamily: TypeAlias = Tuple[Union[str, None], Union[int, None]]
+UnixFamily: TypeAlias = str
+SocketAddress: TypeAlias = Union[InetFamily, UnixFamily]
 
 
 class SocketWriter(Writer):
@@ -22,9 +27,9 @@ class SocketWriter(Writer):
             self._logger.info("initialize SocketWriter to %s (buffer_size=%s)",
                               config.location, config.buffer_size)
 
-        self._buffer = LineBuffer(config.buffer_size) if config.buffer_size > 0 else None
+        self._buffer: Optional[LineBuffer] = LineBuffer(config.buffer_size) if config.buffer_size > 0 else None
         self._lock = threading.Lock()
-        self._sock = None
+        self._sock: Optional[socket.socket] = None
 
         if "udp" in config.location:
             self._init_udp(config.location)
@@ -38,9 +43,9 @@ class SocketWriter(Writer):
 
     def _init_udp(self, location: str):
         parsed = urlparse(location)
-        self._address = (parsed.hostname, parsed.port)
+        self._address: SocketAddress = (parsed.hostname, parsed.port)
         try:
-            if type(ip_address(self._address[0])) is IPv6Address:
+            if self._address[0] is not None and type(ip_address(self._address[0])) is IPv6Address:
                 self._family = socket.AF_INET6
             else:
                 self._family = socket.AF_INET
@@ -55,6 +60,8 @@ class SocketWriter(Writer):
     def _background_flush(self) -> None:
         while True:
             time.sleep(5)
+            if self._buffer is None or self._sock is None:
+                continue
             if len(self._buffer) > 0:
                 with self._lock:
                     try:
@@ -74,6 +81,8 @@ class SocketWriter(Writer):
                 self._logger.error("exception during socket acquire: %s", e)
 
     def _write_buffer(self, line: str) -> None:
+        if self._buffer is None or self._sock is None:
+            return
         with self._lock:
             if self._buffer.append(line):
                 try:
@@ -82,6 +91,8 @@ class SocketWriter(Writer):
                     self._logger.error("failed to write buffer, including line=%s", line)
 
     def _write_socket(self, line: str) -> None:
+        if self._sock is None:
+            return
         try:
             self._sock.sendto(bytes(line, encoding="utf-8"), self._address)
         except IOError:
@@ -97,4 +108,6 @@ class SocketWriter(Writer):
             self._write_socket(line)
 
     def close(self) -> None:
+        if self._sock is None:
+            return
         self._sock.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from typing import Dict, Optional
+from typing import Dict
 
 from spectator import Config
 
@@ -30,7 +30,7 @@ class ConfigTest(unittest.TestCase):
                 pass
 
     @staticmethod
-    def get_location(location: Optional[str]) -> str:
+    def get_location(location: str) -> str:
         return Config(location).location
 
     def test_is_valid_output_location(self):


### PR DESCRIPTION
Since we want to add the `py.typed` marker to this library, we need to check and fix the types.

This change will enable the following pull request:

https://github.com/Netflix/spectator-py/pull/86

Due to how we are using TypeAliases, we need a Python >= 3.10. Given the status of Python versions, with 3.8 and 3.9 being end-of-life, we have updated the supported versions, and set the minimum version to 3.10.

https://devguide.python.org/versions/